### PR TITLE
Feat pagination in drug list

### DIFF
--- a/backend/routers/medicament.py
+++ b/backend/routers/medicament.py
@@ -8,5 +8,6 @@ router = APIRouter()
 
 @router.get("/medicament/search/", status_code=status.HTTP_200_OK)
 async def search_medicamentos_route(db: Session = Depends(get_db)):
-    medicamentos = db.query(Drug).all()
+    limit: int = 10 
+    medicamentos = db.query(Drug).limit(limit).all()
     return [MedicamentResponse.from_orm(med) for med in medicamentos]


### PR DESCRIPTION
# Implementação de Limite de Resultados na Busca de Medicamentos
## Descrição
Este PR adiciona um limite ao número de registros retornados pelo endpoint /medicament/search/. Agora, a busca retorna no máximo 10 (número que pode ser editado na pasta routers arquivo medicaments.py) medicamentos por requisição, reduzindo a carga na API e melhorando a performance ao evitar a recuperação de todos os registros do banco de dados de uma só vez.

Para essa função rodar, nenhum parâmetro é esperado ser recebido do frontend, além do Banco de dados, para testar, leia o tópico "Como testar"

## Principais Mudanças
Adicionada a variável limit = 10, que restringe o número de resultados retornados.

A query foi alterada para usar .limit(limit), garantindo que apenas os primeiros 10 registros sejam recuperados.

## Impacto
✅ Melhora a eficiência da consulta ao banco, evitando retornos desnecessários.
✅ Facilita a escalabilidade, pois reduz o consumo de memória e processamento.
✅ Prepara a API para futuras melhorias, como paginação dinâmica por limit e skip.

## Como testar
Rode o docker e teste a função /medicament/search/, deve retornar os 10 primeiros medicamentos do Banco de Dados.
Caso queira aumentar ou diminuir, vá ao arquivo Medicaments.py na pasta routers e troque o valor da variável limit, dê um refresh no swagger e veja se retorna a quantidade esperada em relação ao limit