### PR TITLE
Feat  return all pharma to dropdown

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from routers.user_drugs import router as user_drugs
 from routers.medicament import router as pesquisar_medicamentos
 from dependencies.auth_dependency import router as auth
 from routers.interactions import router as interactions
+from routers.pharma import router as pharma
 from database import get_db
 from sqlalchemy.orm import Session
 from fastapi.middleware.cors import CORSMiddleware
@@ -23,6 +24,7 @@ app.include_router(user_drugs)
 app.include_router(auth)
 app.include_router(pesquisar_medicamentos)
 app.include_router(interactions)
+app.include_router(pharma)
 
 
 @app.get("/")

--- a/backend/routers/pharma.py
+++ b/backend/routers/pharma.py
@@ -1,17 +1,19 @@
 from fastapi import APIRouter, Depends, status, Query
 from sqlalchemy.orm import Session
 from database import get_db
-from schemas.pharma import Pharma
-from models import Pharma
+from schemas.pharma import Pharma as Pharma_Schemas
+from models import Pharma as Pharma_Models
 
 router = APIRouter()
 
 @router.get("/search/pharma/", status_code=status.HTTP_200_OK)
 async def search_pharma(db: Session = Depends(get_db), name: str = Query(None)):
 
-    if name:
-        query = query.filter(Pharma.pharma_name.ilike(f"%{name}%"),)
-        
-    pharma = db.query(Pharma).all()
+    query = db.query(Pharma_Models)
 
-    return [Pharma.from_orm(med) for med in pharma]
+    if name:
+        query = query.filter(Pharma_Models.pharma_name.ilike(f"%{name}%"))
+        
+    pharma = query.all()
+
+    return [Pharma_Schemas.from_orm(pha) for pha in pharma]

--- a/backend/routers/pharma.py
+++ b/backend/routers/pharma.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends, status, Query
+from sqlalchemy.orm import Session
+from database import get_db
+from schemas.pharma import Pharma
+from models import Pharma
+
+router = APIRouter()
+
+@router.get("/search/pharma/", status_code=status.HTTP_200_OK)
+async def search_pharma(db: Session = Depends(get_db), name: str = Query(None)):
+
+    if name:
+        query = query.filter(Pharma.pharma_name.ilike(f"%{name}%"),)
+        
+    pharma = db.query(Pharma).all()
+
+    return [Pharma.from_orm(med) for med in pharma]

--- a/backend/routers/pharma.py
+++ b/backend/routers/pharma.py
@@ -6,8 +6,8 @@ from models import Pharma as Pharma_Models
 
 router = APIRouter()
 
-@router.get("/search/pharma/", status_code=status.HTTP_200_OK)
-async def search_pharma(db: Session = Depends(get_db), name: str = Query(None)):
+@router.get("/pharma", status_code=status.HTTP_200_OK)
+async def pharma(db: Session = Depends(get_db), name: str = Query(None)):
 
     query = db.query(Pharma_Models)
 

--- a/backend/schemas/pharma.py
+++ b/backend/schemas/pharma.py
@@ -1,4 +1,8 @@
 from pydantic import BaseModel
 
 class Pharma(BaseModel):
-    name: str
+    pharma_name: str 
+
+    class Config:
+        orm_mode = True
+        from_attributes = True  

--- a/backend/schemas/pharma.py
+++ b/backend/schemas/pharma.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel
+
+class Pharma(BaseModel):
+    name: str


### PR DESCRIPTION
## Descrição:
Este PR adiciona um endpoint para buscar medicamentos pelo nome ou parte do nome. A busca é realizada de forma case-insensitive usando ILIKE.

## Alterações principais:

Criado o endpoint GET /search/pharma/

Ajustado o schema PharmaSchema para refletir corretamente o modelo do banco de dados

## Como Testar 
Acesse o endpoint GET /search/pharma/ passando um parâmetro name na URL com o nome (ou parte do nome) do medicamento que deseja buscar.

Verifique a resposta: O retorno deve ser uma lista de medicamentos que correspondem ao nome pesquisado.

### Teste diferentes cenários, como:

Buscar um medicamento existente no banco de dados.

Fazer uma busca parcial (exemplo: "parac" deve retornar "paracetamol").

Buscar um nome inexistente para verificar se retorna uma lista vazia.

Não passar nenhum parâmetro name para ver se retorna todos os medicamentos cadastrados