### PR TITLE
Feat: tests in users routers

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -16,8 +16,3 @@ def create_user(user: schema.UserCreate, db: Session = Depends(get_db)):
 @router.post("/login", status_code=status.HTTP_201_CREATED)
 def login_user(login: schema.UserLogin, db: Session = Depends(get_db)):
     return controller.login_user(db, login)
-
-
-@router.get("/me")
-def get_user(current_user=Depends(get_current_user)):
-    return current_user

--- a/backend/tests/test_controllers/test_interactions.py
+++ b/backend/tests/test_controllers/test_interactions.py
@@ -1,9 +1,4 @@
-from fastapi.testclient import TestClient
-from models import Interaction, Base  # Certifique-se de importar o modelo correto
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy import create_engine
-
-from controllers.interactions import check_interactions
+from models import Interaction # Certifique-se de importar o modelo correto
 
 
 def test_check_interactions_without_medicaments_stored_should_return_404(

--- a/backend/tests/test_controllers/test_users.py
+++ b/backend/tests/test_controllers/test_users.py
@@ -1,4 +1,3 @@
-# Mexer aqui depois que adicionar o regex de email no back
 from models import User
 from dependencies.auth_dependency import hash_password
 

--- a/backend/tests/test_controllers/test_users.py
+++ b/backend/tests/test_controllers/test_users.py
@@ -15,8 +15,28 @@ def test_check_register_user_should_return_201(test_client, db_session):
         "/users/signup", json=teste_case
     )
 
-    response_data = response.json()
-    
     assert response.status_code == 201
+
+    response_data = response.json()
     assert "access_token" in response_data
     assert response_data["token_type"] == "Bearer"
+
+
+def test_check_register_user_should_return_401(test_client, db_session):
+    assert db_session.query(User).count() == 0
+    
+    db_session.add(User(name="teste", email="teste@gmail.com", password="Senha123!"))
+    db_session.commit()
+
+    teste_case = {"name": "teste", "email": "teste@gmail.com", "password": "Senha123!"}
+
+    response = test_client.post(
+        "/users/signup", json=teste_case
+    )
+
+    response_data = response.json()
+    
+    assert response.status_code == 401
+
+    response_data = response.json()
+    assert response_data["detail"] == "User already created"

--- a/backend/tests/test_controllers/test_users.py
+++ b/backend/tests/test_controllers/test_users.py
@@ -1,10 +1,7 @@
 # Mexer aqui depois que adicionar o regex de email no back
 from models import User
-from routers import users
-from fastapi import FastAPI
-app = FastAPI()
+from dependencies.auth_dependency import hash_password
 
-app.include_router(users.router)
 
 def test_register_user_should_return_201(test_client, db_session):
     assert db_session.query(User).count() == 0
@@ -57,3 +54,42 @@ def test_register_user_should_return_400(test_client, db_session):
 
     response_data = response.json()
     assert response_data["detail"] == "A senha deve conter pelo menos 8 caracteres, uma letra maiúscula, uma letra minúscula e um caractere especial."
+
+
+def test_user_login_should_return_201(test_client, db_session):
+    assert db_session.query(User).count() == 0
+
+    hashed_password = hash_password("Senha123!")
+    db_session.add(User(name="teste", email="teste@gmail.com", password=hashed_password))
+    db_session.commit()
+
+    teste_case = {"email": "teste@gmail.com", "password": "Senha123!"}
+
+    response = test_client.post(
+        "/users/login", json=teste_case
+    )
+
+    response_data = response.json()
+    
+    assert response.status_code == 201
+
+    response_data = response.json()
+    assert "access_token" in response_data
+    assert response_data["token_type"] == "Bearer"
+
+
+def test_user_login_should_return_401(test_client, db_session):
+    assert db_session.query(User).count() == 0
+
+    teste_case = {"email": "teste@gmail.com", "password": "Senha123!"}
+
+    response = test_client.post(
+        "/users/login", json=teste_case
+    )
+
+    response_data = response.json()
+    
+    assert response.status_code == 401
+
+    response_data = response.json()
+    assert response_data["detail"] == "Incorrect username or password"

--- a/backend/tests/test_controllers/test_users.py
+++ b/backend/tests/test_controllers/test_users.py
@@ -1,0 +1,22 @@
+# Mexer aqui depois que adicionar o regex de email no back
+from models import User
+from routers import users
+from fastapi import FastAPI
+app = FastAPI()
+
+app.include_router(users.router)
+
+def test_check_register_user_should_return_201(test_client, db_session):
+    assert db_session.query(User).count() == 0
+
+    teste_case = {"name": "teste", "email": "teste@gmail.com", "password": "Senha123!"}
+
+    response = test_client.post(
+        "/users/signup", json=teste_case
+    )
+
+    response_data = response.json()
+    
+    assert response.status_code == 201
+    assert "access_token" in response_data
+    assert response_data["token_type"] == "Bearer"

--- a/backend/tests/test_controllers/test_users.py
+++ b/backend/tests/test_controllers/test_users.py
@@ -3,7 +3,7 @@ from models import User
 from dependencies.auth_dependency import hash_password
 
 
-def test_register_user_should_return_201(test_client, db_session):
+def test_register_user_with_valid_body_should_return_201(test_client, db_session):
     assert db_session.query(User).count() == 0
 
     teste_case = {"name": "teste", "email": "teste@gmail.com", "password": "Senha123!"}
@@ -19,7 +19,7 @@ def test_register_user_should_return_201(test_client, db_session):
     assert response_data["token_type"] == "Bearer"
 
 
-def test_register_user_should_return_401(test_client, db_session):
+def test_register_user_with_user_already_created_should_return_401(test_client, db_session):
     assert db_session.query(User).count() == 0
 
     db_session.add(User(name="teste", email="teste@gmail.com", password="Senha123!"))
@@ -39,7 +39,7 @@ def test_register_user_should_return_401(test_client, db_session):
     assert response_data["detail"] == "User already created"
 
 
-def test_register_user_should_return_400(test_client, db_session):
+def test_register_user_with_invalid_password_should_return_400(test_client, db_session):
     assert db_session.query(User).count() == 0
 
     teste_case = {"name": "teste", "email": "teste@gmail.com", "password": "Senha123"}
@@ -56,7 +56,7 @@ def test_register_user_should_return_400(test_client, db_session):
     assert response_data["detail"] == "A senha deve conter pelo menos 8 caracteres, uma letra maiúscula, uma letra minúscula e um caractere especial."
 
 
-def test_user_login_should_return_201(test_client, db_session):
+def test_user_login_with_account_created_should_return_201(test_client, db_session):
     assert db_session.query(User).count() == 0
 
     hashed_password = hash_password("Senha123!")
@@ -78,7 +78,7 @@ def test_user_login_should_return_201(test_client, db_session):
     assert response_data["token_type"] == "Bearer"
 
 
-def test_user_login_should_return_401(test_client, db_session):
+def test_user_login_with_account_not_created_should_return_401(test_client, db_session):
     assert db_session.query(User).count() == 0
 
     teste_case = {"email": "teste@gmail.com", "password": "Senha123!"}

--- a/backend/tests/test_controllers/test_users.py
+++ b/backend/tests/test_controllers/test_users.py
@@ -6,7 +6,7 @@ app = FastAPI()
 
 app.include_router(users.router)
 
-def test_check_register_user_should_return_201(test_client, db_session):
+def test_register_user_should_return_201(test_client, db_session):
     assert db_session.query(User).count() == 0
 
     teste_case = {"name": "teste", "email": "teste@gmail.com", "password": "Senha123!"}
@@ -22,9 +22,9 @@ def test_check_register_user_should_return_201(test_client, db_session):
     assert response_data["token_type"] == "Bearer"
 
 
-def test_check_register_user_should_return_401(test_client, db_session):
+def test_register_user_should_return_401(test_client, db_session):
     assert db_session.query(User).count() == 0
-    
+
     db_session.add(User(name="teste", email="teste@gmail.com", password="Senha123!"))
     db_session.commit()
 
@@ -40,3 +40,20 @@ def test_check_register_user_should_return_401(test_client, db_session):
 
     response_data = response.json()
     assert response_data["detail"] == "User already created"
+
+
+def test_register_user_should_return_400(test_client, db_session):
+    assert db_session.query(User).count() == 0
+
+    teste_case = {"name": "teste", "email": "teste@gmail.com", "password": "Senha123"}
+
+    response = test_client.post(
+        "/users/signup", json=teste_case
+    )
+
+    response_data = response.json()
+    
+    assert response.status_code == 400
+
+    response_data = response.json()
+    assert response_data["detail"] == "A senha deve conter pelo menos 8 caracteres, uma letra maiúscula, uma letra minúscula e um caractere especial."


### PR DESCRIPTION
# Descricao
Este pull request adiciona testes para as rotas de cadastro de usuário e gerenciamento de medicamentos. As alterações incluem:

Testes de Cadastro de Usuário:

Adicionei testes para garantir que os usuários sejam cadastrados corretamente e que as respostas da API sejam apropriadas, incluindo a verificação do código de status.

Testes de Login de Usuário:

Mesma coisa para o caso de login, onde a rota sera testada para caso de retorno da API possivel.

## Como Testar 
1. Rode um docker compose up 
2. Executar testes rodando um : docker exec -it MedicaAppApi /bin/bash
3. Enviar esse comando para rodar os testes : pytest -vvv --disable-pytest-warnings

Devera sair um resultado como esse, indicando que os testes foram bem sucedidos : 
![image](https://github.com/user-attachments/assets/efa975a4-88d9-47df-9717-7b67d6b15c6a)