### PR TITLE
Feat: tests in router pharma

### DIFF
--- a/backend/tests/test_controllers/test_pharma.py
+++ b/backend/tests/test_controllers/test_pharma.py
@@ -1,0 +1,23 @@
+from models import Pharma
+
+def test_list_pharma_should_retun_200(test_client, db_session):
+    assert db_session.query(Pharma).count() == 0
+
+    pharma = Pharma(
+        pharma_name="Dipirona",
+    )
+
+    db_session.add(pharma)
+    db_session.commit()
+
+    response = test_client.get("/pharma")
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+    response_filtered = test_client.get("/pharma?name=Dipirona")
+    assert response_filtered.status_code == 200
+    assert len(response_filtered.json()) == 1
+
+    response_filtered = test_client.get("/pharma?name=Novalgina")
+    assert response_filtered.status_code == 200
+    assert len(response_filtered.json()) == 0

--- a/backend/tests/test_controllers/test_pharma.py
+++ b/backend/tests/test_controllers/test_pharma.py
@@ -1,10 +1,10 @@
 from models import Pharma
 
-def test_list_pharma_should_retun_200(test_client, db_session):
+def test_list_pharma_with_different_parameters_should_retun_200(test_client, db_session):
     assert db_session.query(Pharma).count() == 0
 
     pharma = Pharma(
-        pharma_name="Dipirona",
+        pharma_name="Dipirona"
     )
 
     db_session.add(pharma)


### PR DESCRIPTION

# Descricao
Este pull request adiciona testes para a rota de pharma:

Adicionei testes para garantir que quando pesquise pelo farmaco retorne a lista completa, se quando ele procura por um nome especifico, ele retorna esse nome e se quando procura por um nome inexistente no banco, retorna uma lista vazia.

## Como Testar
Rode um docker compose up
Executar testes rodando um : docker exec -it MedicaAppApi /bin/bash
Enviar esse comando para rodar os testes : pytest -vvv --disable-pytest-warnings
Devera sair um resultado como esse, indicando que os testes foram bem sucedidos :
![image](https://github.com/user-attachments/assets/065299b9-e6c6-4dbf-9913-12d717400b7f)
