### PR TITLE
Feat: router medicament tests 

### DIFF
--- a/backend/tests/test_controllers/test_medicament.py
+++ b/backend/tests/test_controllers/test_medicament.py
@@ -1,8 +1,6 @@
 from models import Drug
 
-def test_list_medicaments_should_retun_200(test_client, db_session):
-    assert db_session.query(Drug).count() == 0
-
+def create_new_drug(db_session):
     drug1 = Drug(
         farmaco = 'Dipirona',
         detentor = 'H1',
@@ -29,19 +27,134 @@ def test_list_medicaments_should_retun_200(test_client, db_session):
     db_session.add(drug2)
     db_session.commit()
 
+    drug3 = Drug(
+        farmaco = 'Cafeina',
+        detentor = 'H3',
+        medicamento = 'Dorflex',
+        registro = '1935344',
+        concentracao = '2ml',
+        forma_farmaceutica = 'dor flex',
+        data_inclusao = '01/01/2002'
+    )
+
+    db_session.add(drug3)
+    db_session.commit()
+
+
+def test_list_medicaments_should_retun_all_medicaments(test_client, db_session):
+    assert db_session.query(Drug).count() == 0
+
+    create_new_drug(db_session)
 
     response = test_client.get("/medicament/search")
     assert response.status_code == 200
-    assert len(response.json()) == 2
+    assert len(response.json()["items"]) == 3
 
-    response_filtered = test_client.get("/medicament/search?name=Dipirona")
-    assert response_filtered.status_code == 200
-    assert len(response_filtered.json()) == 1
 
-    response_filtered = test_client.get("/medicament/search?name=Novalgina")
-    assert response_filtered.status_code == 200
-    assert len(response_filtered.json()) == 1
+def test_list_medicaments_search_per_name_should_return_medicament(test_client, db_session):
+    assert db_session.query(Drug).count() == 0
 
-    response_filtered = test_client.get("/medicament/search?name=Dorflex")
-    assert response_filtered.status_code == 200
-    assert len(response_filtered.json()) == 0
+    create_new_drug(db_session)
+
+    response = test_client.get("/medicament/search/?name=Novalgina")
+
+    data = response.json()
+
+    assert response.status_code == 200
+    assert len(data["items"]) == 1
+    assert data["items"][0]["medicamento"] == "Novalgina"
+
+
+def test_list_medicaments_search_per_half_name_should_return_medicament(test_client, db_session):
+    assert db_session.query(Drug).count() == 0
+
+    create_new_drug(db_session)
+
+    response = test_client.get("/medicament/search/?name=noval")
+
+    data = response.json()
+
+    assert response.status_code == 200
+    assert len(data["items"]) == 1
+    assert data["items"][0]["medicamento"] == "Novalgina"
+
+
+def test_list_medicaments_search_per_pharma_should_return_medicament(test_client, db_session):
+    assert db_session.query(Drug).count() == 0
+
+    create_new_drug(db_session)
+
+    response = test_client.get("/medicament/search/?name=Dipirona")
+
+    data = response.json()
+
+    assert response.status_code == 200
+    assert len(data["items"]) == 1
+    assert data["items"][0]["medicamento"] == "Novalgina"
+
+
+def test_list_medicaments_search_per_half_pharma_should_return_medicament(test_client, db_session):
+    assert db_session.query(Drug).count() == 0
+
+    create_new_drug(db_session)
+
+    response = test_client.get("/medicament/search/?name=dipi")
+
+    data = response.json()
+
+    assert response.status_code == 200
+    assert len(data["items"]) == 1
+    assert data["items"][0]["medicamento"] == "Novalgina"
+
+
+def test_list_medicaments_skip_limit(test_client, db_session):
+    assert db_session.query(Drug).count() == 0
+
+    create_new_drug(db_session)
+
+    response = test_client.get("/medicament/search/?skip=1&limit=1")
+
+    data = response.json()
+
+    assert response.status_code == 200
+    assert len(data["items"]) == 1
+    assert data["items"][0]["medicamento"] == "Dorflex"
+
+
+def test_list_medicaments_should_return_a_empty_list(test_client, db_session):
+    assert db_session.query(Drug).count() == 0
+
+    create_new_drug(db_session)
+
+    response = test_client.get("/medicament/search/?name=Zolpidem")
+
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["items"] == []
+
+def test_list_medicaments_limit_max_value_should_return_200(test_client, db_session):
+    assert db_session.query(Drug).count() == 0
+
+    create_new_drug(db_session)
+
+    response = test_client.get("/medicament/search/?limit=17000")
+
+    data = response.json()
+
+    assert response.status_code == 200
+    assert len(data["items"]) == 3
+
+
+def test_list_medicaments_skip_min_value_should_return_200(test_client, db_session):
+    assert db_session.query(Drug).count() == 0
+
+    create_new_drug(db_session)
+
+    response = test_client.get("/medicament/search/?skip=0")
+
+    data = response.json()
+
+    assert response.status_code == 200
+    assert len(data["items"]) == 3
+    

--- a/backend/tests/test_controllers/test_medicament.py
+++ b/backend/tests/test_controllers/test_medicament.py
@@ -1,0 +1,47 @@
+from models import Drug
+
+def test_list_medicaments_should_retun_200(test_client, db_session):
+    assert db_session.query(Drug).count() == 0
+
+    drug1 = Drug(
+        farmaco = 'Dipirona',
+        detentor = 'H1',
+        medicamento = 'Novalgina',
+        registro = '19213124',
+        concentracao = '25gm',
+        forma_farmaceutica = 'acl no',
+        data_inclusao = '21/12/2002'
+    )
+
+    db_session.add(drug1)
+    db_session.commit()
+
+    drug2 = Drug(
+        farmaco = 'Tadalafil',
+        detentor = 'H1',
+        medicamento = 'Cialis',
+        registro = '192131234424',
+        concentracao = '20ml',
+        forma_farmaceutica = 'ska la',
+        data_inclusao = '21/12/2022'
+    )
+
+    db_session.add(drug2)
+    db_session.commit()
+
+
+    response = test_client.get("/medicament/search")
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+    response_filtered = test_client.get("/medicament/search?name=Dipirona")
+    assert response_filtered.status_code == 200
+    assert len(response_filtered.json()) == 1
+
+    response_filtered = test_client.get("/medicament/search?name=Novalgina")
+    assert response_filtered.status_code == 200
+    assert len(response_filtered.json()) == 1
+
+    response_filtered = test_client.get("/medicament/search?name=Dorflex")
+    assert response_filtered.status_code == 200
+    assert len(response_filtered.json()) == 0

--- a/backend/tests/test_controllers/test_pharma.py
+++ b/backend/tests/test_controllers/test_pharma.py
@@ -1,6 +1,6 @@
 from models import Pharma
 
-def test_list_pharma_with_different_parameters_should_retun_200(test_client, db_session):
+def test_list_pharma_with_a_valid_input_should_return_the_searched_pharma(test_client, db_session):
     assert db_session.query(Pharma).count() == 0
 
     pharma = Pharma(
@@ -18,6 +18,21 @@ def test_list_pharma_with_different_parameters_should_retun_200(test_client, db_
     assert response_filtered.status_code == 200
     assert len(response_filtered.json()) == 1
 
+
+def test_list_pharma_with_an_invalid_input_should_return_an_empty_list(test_client, db_session):
+    assert db_session.query(Pharma).count() == 0
+
+    pharma = Pharma(
+        pharma_name="Dipirona"
+    )
+
+    db_session.add(pharma)
+    db_session.commit()
+
+    response = test_client.get("/pharma")
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    
     response_filtered = test_client.get("/pharma?name=Novalgina")
     assert response_filtered.status_code == 200
     assert len(response_filtered.json()) == 0

--- a/backend/tests/test_controllers/test_pharma.py
+++ b/backend/tests/test_controllers/test_pharma.py
@@ -1,8 +1,6 @@
 from models import Pharma
 
-def test_list_pharma_with_a_valid_input_should_return_the_searched_pharma(test_client, db_session):
-    assert db_session.query(Pharma).count() == 0
-
+def create_pharma(db_session):
     pharma = Pharma(
         pharma_name="Dipirona"
     )
@@ -10,11 +8,37 @@ def test_list_pharma_with_a_valid_input_should_return_the_searched_pharma(test_c
     db_session.add(pharma)
     db_session.commit()
 
+    pharma2 = Pharma(
+        pharma_name="Aspirina"
+    )
+
+    db_session.add(pharma2)
+    db_session.commit()
+
+def test_list_pharma_with_none_input_should_return_all_pharmas(test_client, db_session):
+    assert db_session.query(Pharma).count() == 0
+
+    create_pharma(db_session)
     response = test_client.get("/pharma")
     assert response.status_code == 200
-    assert len(response.json()) == 1
+    assert len(response.json()) == 2
 
+def test_list_pharma_with_a_valid_input_should_return_the_searched_pharma(test_client, db_session):
+    assert db_session.query(Pharma).count() == 0
+
+    create_pharma(db_session)
+    
     response_filtered = test_client.get("/pharma?name=Dipirona")
+    assert response_filtered.status_code == 200
+    assert len(response_filtered.json()) == 1
+
+
+def test_list_pharma_with_a_half_input_should_return_the_half_searched_pharma(test_client, db_session):
+    assert db_session.query(Pharma).count() == 0
+
+    create_pharma(db_session)
+    
+    response_filtered = test_client.get("/pharma?name=dipi")
     assert response_filtered.status_code == 200
     assert len(response_filtered.json()) == 1
 
@@ -22,17 +46,8 @@ def test_list_pharma_with_a_valid_input_should_return_the_searched_pharma(test_c
 def test_list_pharma_with_an_invalid_input_should_return_an_empty_list(test_client, db_session):
     assert db_session.query(Pharma).count() == 0
 
-    pharma = Pharma(
-        pharma_name="Dipirona"
-    )
+    create_pharma(db_session)
 
-    db_session.add(pharma)
-    db_session.commit()
-
-    response = test_client.get("/pharma")
-    assert response.status_code == 200
-    assert len(response.json()) == 1
-    
-    response_filtered = test_client.get("/pharma?name=Novalgina")
+    response_filtered = test_client.get("/pharma?name=Zolpidem")
     assert response_filtered.status_code == 200
     assert len(response_filtered.json()) == 0


### PR DESCRIPTION
# Descricao
Este pull request adiciona testes para a rota de medicament:

Adicionei testes para garantir que quando pesquise pelo medicamento ou farmaco retorne a lista completa, se quando ele procura por um nome especifico, ele retorna esse nome e se quando procura por um nome inexistente no banco, retorna uma lista vazia.
Alem disso, tambem contempla os parametros Skip e Limit

Alem disso, refiz a logica do codigo de testes da rota pharma para ficar em um padrao que melhore a legibilidade dos testes

## Como Testar
Rode um docker compose up
Executar testes rodando um : docker exec -it MedicaAppApi /bin/bash
Enviar esse comando para rodar os testes : pytest -vvv --disable-pytest-warnings
Devera sair um resultado como esse, indicando que os testes foram bem sucedidos :
![image](https://github.com/user-attachments/assets/f68d315e-292e-41ac-bda9-28f5b88b4e85)